### PR TITLE
Adds support to send raw MIME messages

### DIFF
--- a/META.json
+++ b/META.json
@@ -41,6 +41,7 @@
       "runtime" : {
          "requires" : {
             "Class::Accessor::Lite" : "0",
+            "File::Temp" : "0",
             "Furl" : "0",
             "HTTP::Request::Common" : "0",
             "IO::Socket::SSL" : "0",

--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'JSON::XS';
 requires 'URI';
 requires 'Try::Tiny';
 requires 'HTTP::Request::Common';
+requires 'File::Temp'; 
 requires 'perl', '5.010000';
 
 on 'test' => sub {

--- a/lib/WebService/Mailgun.pm
+++ b/lib/WebService/Mailgun.pm
@@ -1,4 +1,6 @@
 package WebService::Mailgun;
+
+
 use 5.008001;
 use strict;
 use warnings;
@@ -9,6 +11,8 @@ use URI;
 use Try::Tiny;
 use Carp;
 use HTTP::Request::Common;
+use File::Temp;
+
 
 our $VERSION = "0.11";
 our $API_BASE = 'api.mailgun.net/v3';
@@ -105,7 +109,7 @@ sub message {
         @content = @$args;
     }
     else {
-        die 'unsupport argument. message() need HashRef or ArrayRef.';
+        die 'unsupport argument. message() needs a hash ref or an array ref.';
     }
 
     my $req = POST $self->domain_api_url('messages'), Content_type => 'form-data', Content => \@content;
@@ -113,6 +117,65 @@ sub message {
     my $res = $self->client->request($req);
     $self->decode_response($res);
 }
+
+
+
+sub mime { 
+		
+    my ($self, $args) = @_;
+
+    if (ref($args) eq 'HASH') {
+        # Well, good!
+    }
+    else {
+        die 'unsupport argument. mime() needs a hash ref.';
+    }
+	
+	
+	my $tmp = undef; 
+
+	if(exists($args->{message})){
+		$tmp = File::Temp->new();
+		
+		if(ref $args->{message} eq 'SCALAR'){ 
+			# save from a ref
+			print $tmp ${$args->{message}};
+			seek $tmp, 0, 0;
+		}
+		else {
+			# Save from a string
+			print $tmp $args->{message};
+			seek $tmp, 0, 0;
+		}
+		$args->{message} = [$tmp->filename];
+	}
+	elsif(exists($args->{file})){ 
+		if(-f $args->{file}){ 
+			$args->{message} =  [$args->{file}];
+			delete $args->{file}; 
+		}
+		else { 
+			die "cannot find file, " . $args->{file}; 
+		}
+	}
+	
+	# Put it back together: 
+	my @content = %$args;
+
+    my $req = POST $self->domain_api_url('messages.mime'), 
+		Content_Type => 'form-data', 
+		Content => \@content;
+		
+    my $res = $self->client->request($req);
+	
+	undef $tmp; 
+	
+    $self->decode_response($res);
+
+}
+
+
+
 
 sub lists {
     my $self = shift;
@@ -275,6 +338,43 @@ Send email message.
     });
 
 L<https://documentation.mailgun.com/en/latest/api-sending.html#sending>
+
+=head2 mime($args)
+
+Send a MIME message you build yourself, usually by using a library to create that MIME message. 
+The C<to> parameter needs to be passed as one of the arguments. 
+Either the C<file> or C<message> parameter will also need to be passed. 
+
+The C<file> parameter should contain the path to the filename that holds the MIME message. 
+The C<message> parameter should contain either a string or a reference to a string that holds the MIME message: 
+
+    # send MIME message via a filename: 
+    my $res = $mailgun->message({
+    	to      => 'bar@example.com',
+		file    => '/path/to/filename.mime',	
+    });
+
+    # send MIME message via a string:
+	use MIME::Entity; 
+	my $str = MIME::Entity->build(
+		From    => 'justin@dadamailproject.com',
+        To      => 'justin@dadamailproject.com',
+        Subject => "Subject",
+        Data    => 'Messag4')->as_string;
+	
+    my $res = $mailgun->message({
+    	to       => 'bar@example.com',
+		message  => $str,
+    });
+
+    # or send MIME message via a string ref:	
+    my $res = $mailgun->message({
+    	to       => 'bar@example.com',
+		message  => \$str,
+    });
+
+L<https://documentation.mailgun.com/en/latest/api-sending.html#sending>
+
 
 =head2 lists()
 

--- a/lib/WebService/Mailgun.pm
+++ b/lib/WebService/Mailgun.pm
@@ -109,8 +109,8 @@ sub message {
         @content = @$args;
     }
     else {
-        die 'unsupport argument. message() needs a hash ref or an array ref.';
-    }
+        die 'unsupport argument. message() need HashRef or ArrayRef.';    
+	}
 
     my $req = POST $self->domain_api_url('messages'), Content_type => 'form-data', Content => \@content;
 

--- a/t/04_mime.t
+++ b/t/04_mime.t
@@ -1,0 +1,62 @@
+
+use lib qw(../lib);
+use lib qw(lib);
+
+
+
+use strict;
+use Test::More 0.98;
+use Test::Exception;
+use WebService::Mailgun;
+
+my $mime_str = q{Content-Type: text/plain
+Content-Disposition: inline
+Content-Transfer-Encoding: binary
+MIME-Version: 1.0
+From: test@perl.example.com
+To: kan.fushihara@gmail.com
+Subject: Message Subject
+
+Message Body}; 
+
+
+my $mailgun = WebService::Mailgun->new(
+    api_key => 'key-389807c554fdfe0a7757adf0650f7768',
+    domain  => 'sandbox56435abd76e84fa6b03de82540e11271.mailgun.org',
+);
+
+ok my $res = $mailgun->mime({
+	to           => 'kan.fushihara@gmail.com',
+	message      => $mime_str, 
+	'o:testmode' => 'true',
+});
+
+is $res->{message}, 'Queued. Thank you.';
+note $res->{id};
+
+
+ok my $res2 = $mailgun->mime({
+	to           => 'kan.fushihara@gmail.com',
+	message      => \$mime_str, 
+	'o:testmode' => 'true',
+});
+
+is $res2->{message}, 'Queued. Thank you.';
+note $res2->{id};
+
+
+
+ok my $res2 = $mailgun->mime({
+	to           => 'kan.fushihara@gmail.com',
+	file         => './t/corpus/msg1.mime', 
+	'o:testmode' => 'true',
+});
+
+is $res2->{message}, 'Queued. Thank you.';
+note $res2->{id};
+
+dies_ok { my $res3 = $mailgun->message('scalar'); }, 'unsupport', 'mime() needs a hash ref.';
+
+
+done_testing;
+

--- a/t/corpus/msg1.mime
+++ b/t/corpus/msg1.mime
@@ -1,0 +1,9 @@
+Content-Type: text/plain
+Content-Disposition: inline
+Content-Transfer-Encoding: binary
+MIME-Version: 1.0
+From: test@perl.example.com
+To: kan.fushihara@gmail.com
+Subject: Message Subject
+
+Message Body


### PR DESCRIPTION
This PR adds support for sending raw MIME messages, as I asked about in, https://github.com/kan/p5-web-service-mailgun/issues/5

The new method is named, mime(). Documentation of this new method and tests are included in this PR. 

One new prerequisite, File::Temp has been added. 
