### PR TITLE
Switches out JSON::XS to just JSON

### DIFF
--- a/META.json
+++ b/META.json
@@ -45,7 +45,7 @@
             "Furl" : "0",
             "HTTP::Request::Common" : "0",
             "IO::Socket::SSL" : "0",
-            "JSON::XS" : "0",
+            "JSON" : "0",
             "Try::Tiny" : "0",
             "URI" : "0",
             "perl" : "5.010000"

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ my $res = $mailgun->add_list_member('ml@example.com' => {
 Adds multiple members for mailing list.
 
 ```perl
-use JSON::XS; # auto export 'encode_json'
+use JSON; # auto export 'encode_json'
 
 # add members
 my $res = $mailgun->add_list_members('ml@example.com' => {

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'Class::Accessor::Lite';
 requires 'IO::Socket::SSL';
 requires 'Furl';
-requires 'JSON::XS';
+requires 'JSON';
 requires 'URI';
 requires 'Try::Tiny';
 requires 'HTTP::Request::Common';

--- a/lib/WebService/Mailgun.pm
+++ b/lib/WebService/Mailgun.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 
 use Furl;
-use JSON::XS;
+use JSON;
 use URI;
 use Try::Tiny;
 use Carp;
@@ -460,7 +460,7 @@ L<https://documentation.mailgun.com/en/latest/api-mailinglists.html#mailing-list
 
 Adds multiple members for mailing list.
 
-    use JSON::XS; # auto export 'encode_json'
+    use JSON; # auto export 'encode_json'
 
     # add members
     my $res = $mailgun->add_list_members('ml@example.com' => {

--- a/t/02_list_and_event.t
+++ b/t/02_list_and_event.t
@@ -2,7 +2,7 @@ use strict;
 use Test::More 0.98;
 use Test::Exception;
 use WebService::Mailgun;
-use JSON::XS;
+use JSON;
 use String::Random;
 
 my $mailgun = WebService::Mailgun->new(


### PR DESCRIPTION
These changes just uses JSON rather than JSON::XS

Reasons? Slightly better compatibility for environments where JSON::XS is not installed, but JSON::PP is. 
Ability for the user to choose which JSON module to use through ENV variables

All tests are passing. 

The cpanfile.snapshot file still lists, "JSON::XS", but I believe this file is generated and updated by your package manager (Carton?) 
